### PR TITLE
removed the space

### DIFF
--- a/rules/SHARPIVOT/production/hxioc/Possible Handler Poisoning (Methodology).ioc
+++ b/rules/SHARPIVOT/production/hxioc/Possible Handler Poisoning (Methodology).ioc
@@ -71,7 +71,7 @@
             </IndicatorItem>
             <IndicatorItem id="ba563ab1-2285-4dc3-b388-353cd4e01479" condition="matches" preserve-case="false" negate="false">
               <Context document="processEvent" search="processEvent/processCmdLine" type="event" />
-              <Content type="string">url.dll\s*FileProtocolHandler.*://</Content>
+              <Content type="string">url.dll.*FileProtocolHandler.*://</Content>
             </IndicatorItem>
           </Indicator>
         </Indicator>


### PR DESCRIPTION
the \s seems inappropriate and could cause a lot of blind spots since most commands will add a comma directly after the dll 

for example;
regsvr32.exe url.dll,FileProtocolHandler http://just.an.example.com